### PR TITLE
Calc crc of lower-cased filepaths

### DIFF
--- a/helper/crc.go
+++ b/helper/crc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"strings"
 )
 
 var (
@@ -67,6 +68,7 @@ func FilenameCRC32(name string) uint32 {
 	if len(name) == 0 {
 		return 0
 	}
+	name = strings.ToLower(name)
 	if name[len(name)-1] != '\000' {
 		name += "\000"
 	}

--- a/helper/crc_test.go
+++ b/helper/crc_test.go
@@ -14,6 +14,7 @@ func TestFilenameCRC32(t *testing.T) {
 		want uint32
 	}{
 		{name: string("FilenameCRC32"), args: args{name: "test"}, want: 1537663841},
+		{name: string("FilenameCRC32"), args: args{name: "__PFSFileNames__"}, want: 1633159881},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Pretty sure pfs uses a lower-cased filepath for the crc key. 

zone-utilities also does this:
https://github.com/EQEmu/zone-utilities/blob/0cf54d8ef093df437b93f377ede43e69363fdcfa/src/common/pfs.cpp#L85

https://github.com/KimLS/zone-utilities-rs/blob/10a2631daf1e55c6ef2c7183d00a4a546a6a0048/crates/zu_common/src/archive/pfs/writable.rs#L79