### PR TITLE
Add assets subdir support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,14 +123,14 @@ explore-%: ## shortcut for wld-cli to explore a file
 	mkdir -p test/
 	rm -rf test/_*.s3d/
 	rm -rf test/_*.eqg/
-	source .env && go run main.go extract $$EQ_PATH/$*.s3d test/_$*.s3d
+	source .env && go run main.go unzip $$EQ_PATH/$*.s3d test/_$*.s3d
 	wld-cli explore test/_$*.s3d/$*.wld
 
 exploreobjects-%: ## shortcut for wld-cli to explore a file
 	mkdir -p test/
 	rm -rf test/_*.s3d/
 	rm -rf test/_*.eqg/
-	source .env && go run main.go extract $$EQ_PATH/$*.s3d test/_$*.s3d
+	source .env && go run main.go unzip $$EQ_PATH/$*.s3d test/_$*.s3d
 	wld-cli explore test/_$*.s3d/objects.wld
 
 

--- a/quail/dir_read.go
+++ b/quail/dir_read.go
@@ -54,9 +54,7 @@ func (q *Quail) DirRead(path string) error {
 		}
 	}
 
-	q.Textures = make(map[string][]byte)
-
-	dirs, err := os.ReadDir(path)
+	dirs, err := os.ReadDir(path + "/assets")
 	if err != nil {
 		return err
 	}
@@ -64,18 +62,11 @@ func (q *Quail) DirRead(path string) error {
 		if dir.IsDir() {
 			continue
 		}
-		ext := filepath.Ext(dir.Name())
-		if ext == ".wce" {
-			continue
-		}
-		if ext == ".mod" {
-			continue
-		}
-		textureData, err := os.ReadFile(path + "/" + dir.Name())
+		textureData, err := os.ReadFile(path + "/assets/" + dir.Name())
 		if err != nil {
 			return err
 		}
-		q.Textures[dir.Name()] = textureData
+		q.assetAdd(dir.Name(), textureData)
 	}
 
 	return nil

--- a/quail/dir_write.go
+++ b/quail/dir_write.go
@@ -52,20 +52,20 @@ func (q *Quail) DirWrite(path string) error {
 		}
 	}
 
-	for name, data := range q.Textures {
+	if len(q.Assets) > 0 {
+		err = os.MkdirAll(path+"/assets/", 0755)
+		if err != nil {
+			return fmt.Errorf("mkdir: %w", err)
+		}
+	}
+
+	for name, data := range q.Assets {
 
 		/* data, err := fixWonkyDDS(name, texture)
 		if err != nil {
 			return err
 		} */
-		err = os.WriteFile(path+"/"+name, data, 0644)
-		if err != nil {
-			return err
-		}
-	}
-
-	for name, data := range q.BakedLights {
-		err = os.WriteFile(path+"/"+name, data, 0644)
+		err = os.WriteFile(path+"/assets/"+name, data, 0644)
 		if err != nil {
 			return err
 		}

--- a/quail/json_read.go
+++ b/quail/json_read.go
@@ -45,8 +45,6 @@ func (q *Quail) JsonRead(path string) error {
 		}
 	}
 
-	q.Textures = make(map[string][]byte)
-
 	dirs, err := os.ReadDir(baseName)
 	if err != nil {
 		return err
@@ -62,7 +60,7 @@ func (q *Quail) JsonRead(path string) error {
 				fmt.Println("Text", err)
 				continue
 			}
-			q.Textures[dir.Name()] = textureData
+			q.assetAdd(dir.Name(), textureData)
 		}
 	}
 

--- a/quail/json_write.go
+++ b/quail/json_write.go
@@ -42,7 +42,7 @@ func (q *Quail) JsonWrite(path string) error {
 	}
 	os.MkdirAll(strings.TrimSuffix(path, ".json"), 0755)
 
-	for name, data := range q.Textures {
+	for name, data := range q.Assets {
 		err = os.WriteFile(strings.TrimSuffix(path, ".json")+"/"+name, data, 0644)
 		if err != nil {
 			return err

--- a/quail/pfs_read.go
+++ b/quail/pfs_read.go
@@ -40,10 +40,7 @@ func (q *Quail) PfsRead(path string) error {
 	for _, file := range pfs.Files() {
 		ext := strings.ToLower(filepath.Ext(file.Name()))
 		if ext == ".lit" {
-			if q.BakedLights == nil {
-				q.BakedLights = make(map[string][]byte)
-			}
-			q.BakedLights[file.Name()] = file.Data()
+			q.assetAdd(file.Name(), file.Data())
 			continue
 		}
 		reader, err := raw.Read(ext, bytes.NewReader(file.Data()))
@@ -57,5 +54,13 @@ func (q *Quail) PfsRead(path string) error {
 		}
 	}
 
+	return nil
+}
+
+func (q *Quail) assetAdd(name string, data []byte) error {
+	if q.Assets == nil {
+		q.Assets = make(map[string][]byte)
+	}
+	q.Assets[name] = data
 	return nil
 }

--- a/quail/pfs_read.go
+++ b/quail/pfs_read.go
@@ -54,6 +54,45 @@ func (q *Quail) PfsRead(path string) error {
 		}
 	}
 
+	summary := ""
+	if len(q.Wld.TerDefs) > 0 {
+		summary = fmt.Sprintf("%s%d terrain, ", summary, len(q.Wld.TerDefs))
+	}
+	if len(q.Wld.WorldTrees) > 0 {
+		summary = fmt.Sprintf("%s%d trees, ", summary, len(q.Wld.WorldTrees))
+	}
+
+	if len(q.Wld.ActorDefs) > 0 {
+		summary = fmt.Sprintf("%d actors, ", len(q.Wld.ActorDefs))
+	}
+	if len(q.Wld.ModDefs) > 0 {
+		summary = fmt.Sprintf("%s%d models, ", summary, len(q.Wld.ModDefs))
+	}
+	if len(q.Wld.RGBTrackDefs) > 0 {
+		summary = fmt.Sprintf("%s%d rgb tracks, ", summary, len(q.Wld.RGBTrackDefs))
+	}
+
+	if len(q.Wld.MdsDefs) > 0 {
+		summary = fmt.Sprintf("%s%d skinned models, ", summary, len(q.Wld.MdsDefs))
+	}
+	if len(q.Wld.AmbientLights) > 0 {
+		summary = fmt.Sprintf("%s%d lights, ", summary, len(q.Wld.AmbientLights))
+	}
+	if len(q.Wld.AniDefs) > 0 {
+		summary = fmt.Sprintf("%s%d animations, ", summary, len(q.Wld.AniDefs))
+	}
+	if len(q.Wld.TrackDefs) > 0 {
+		summary = fmt.Sprintf("%s%d tracks, ", summary, len(q.Wld.TrackDefs))
+	}
+	if len(q.Wld.DMTrackDef2s) > 0 {
+		summary = fmt.Sprintf("%s%d dmtracks, ", summary, len(q.Wld.DMTrackDef2s))
+	}
+
+	if len(summary) > 0 {
+		summary = summary[:len(summary)-2]
+		fmt.Printf("Converted %s.\n", summary)
+	}
+
 	return nil
 }
 

--- a/quail/pfs_write.go
+++ b/quail/pfs_write.go
@@ -118,18 +118,10 @@ func (e *Quail) S3DExport(fileVersion uint32, pfsVersion int, path string) error
 		isSomethingWritten = true
 	}
 
-	for fileName, textureData := range e.Textures {
-		err := archive.Add(fileName, textureData)
+	for fileName, assetData := range e.Assets {
+		err := archive.Add(fileName, assetData)
 		if err != nil {
-			return fmt.Errorf("addTexture %s: %w", fileName, err)
-		}
-		isSomethingWritten = true
-	}
-
-	for fileName, lightData := range e.BakedLights {
-		err := archive.Add(fileName, lightData)
-		if err != nil {
-			return fmt.Errorf("addLight %s: %w", fileName, err)
+			return fmt.Errorf("addAsset %s: %w", fileName, err)
 		}
 		isSomethingWritten = true
 	}

--- a/quail/quail.go
+++ b/quail/quail.go
@@ -12,11 +12,10 @@ import (
 
 type Quail struct {
 	IsExtensionVersionDump bool
-	Textures               map[string][]byte // Textures are raw texture files
 	Wld                    *wce.Wce
 	WldObject              *wce.Wce
 	WldLights              *wce.Wce
-	BakedLights            map[string][]byte // BakedLights are lightmaps
+	Assets                 map[string][]byte
 }
 
 // New returns a new Quail instance

--- a/quail/raw_read.go
+++ b/quail/raw_read.go
@@ -17,19 +17,17 @@ func (q *Quail) RawRead(in raw.ReadWriter) error {
 	switch val := in.(type) {
 	case *raw.Wld:
 		return q.wldRead(val, in.FileName())
-	case *raw.Dds:
-		return q.ddsRead(val)
-	case *raw.Bmp:
-		return q.bmpRead(val)
-	case *raw.Png:
-		return q.pngRead(val)
-	case *raw.Mod, *raw.Pts, *raw.Prt, *raw.Mds, *raw.Ter, *raw.Lod, *raw.Lay, *raw.Ani, *raw.Lit, *raw.Tog:
+	case *raw.Dds, *raw.Bmp, *raw.Png: // textures
+		return q.assetRead(val)
+	case *raw.Lit: // baked lighting in eqg
+		return q.assetRead(val)
+	case *raw.Txt:
+		return q.assetRead(val)
+	case *raw.Mod, *raw.Pts, *raw.Prt, *raw.Mds, *raw.Ter, *raw.Lod, *raw.Lay, *raw.Ani, *raw.Tog:
 		//fmt.Println("ignoring", in.Identity())
 		return nil // ignored, loaded by wce parsre
 	case *raw.Unk:
-		return nil
-	case *raw.Txt:
-		return nil
+		return q.assetRead(val)
 	default:
 		return fmt.Errorf("unknown type %T", val)
 	}
@@ -42,31 +40,11 @@ func RawRead(in raw.ReadWriter, q *Quail) error {
 	return q.RawRead(in)
 }
 
-func (q *Quail) ddsRead(in *raw.Dds) error {
+func (q *Quail) assetRead(in raw.ReadWriter) error {
 	buf := &bytes.Buffer{}
 	err := in.Write(buf)
 	if err != nil {
-		return fmt.Errorf("write dds: %w", err)
-	}
-	q.assetAdd(in.FileName(), buf.Bytes())
-	return nil
-}
-
-func (q *Quail) bmpRead(in *raw.Bmp) error {
-	buf := &bytes.Buffer{}
-	err := in.Write(buf)
-	if err != nil {
-		return fmt.Errorf("write bmp: %w", err)
-	}
-	q.assetAdd(in.FileName(), buf.Bytes())
-	return nil
-}
-
-func (q *Quail) pngRead(in *raw.Png) error {
-	buf := &bytes.Buffer{}
-	err := in.Write(buf)
-	if err != nil {
-		return fmt.Errorf("write png: %w", err)
+		return fmt.Errorf("write asset %s: %w", in.Identity(), err)
 	}
 	q.assetAdd(in.FileName(), buf.Bytes())
 	return nil

--- a/quail/raw_read.go
+++ b/quail/raw_read.go
@@ -43,41 +43,32 @@ func RawRead(in raw.ReadWriter, q *Quail) error {
 }
 
 func (q *Quail) ddsRead(in *raw.Dds) error {
-	if q.Textures == nil {
-		q.Textures = make(map[string][]byte)
-	}
 	buf := &bytes.Buffer{}
 	err := in.Write(buf)
 	if err != nil {
 		return fmt.Errorf("write dds: %w", err)
 	}
-	q.Textures[in.FileName()] = buf.Bytes()
+	q.assetAdd(in.FileName(), buf.Bytes())
 	return nil
 }
 
 func (q *Quail) bmpRead(in *raw.Bmp) error {
-	if q.Textures == nil {
-		q.Textures = make(map[string][]byte)
-	}
 	buf := &bytes.Buffer{}
 	err := in.Write(buf)
 	if err != nil {
 		return fmt.Errorf("write bmp: %w", err)
 	}
-	q.Textures[in.FileName()] = buf.Bytes()
+	q.assetAdd(in.FileName(), buf.Bytes())
 	return nil
 }
 
 func (q *Quail) pngRead(in *raw.Png) error {
-	if q.Textures == nil {
-		q.Textures = make(map[string][]byte)
-	}
 	buf := &bytes.Buffer{}
 	err := in.Write(buf)
 	if err != nil {
 		return fmt.Errorf("write png: %w", err)
 	}
-	q.Textures[in.FileName()] = buf.Bytes()
+	q.assetAdd(in.FileName(), buf.Bytes())
 	return nil
 }
 

--- a/scripts/texturedump/main.go
+++ b/scripts/texturedump/main.go
@@ -82,7 +82,7 @@ func run() error {
 
 		isModel := strings.Contains(path, "_chr")
 
-		for name, texture := range q.Textures {
+		for name, texture := range q.Assets {
 
 			outPath := ""
 			if isModel {

--- a/wce/wce_eqg.go
+++ b/wce/wce_eqg.go
@@ -86,7 +86,7 @@ func (e *ModDef) Write(token *AsciiWriteToken) error {
 		}
 		fmt.Fprintf(w, "\t\t\tNUMVERTICES %d\n", len(e.Vertices))
 		for i, vert := range e.Vertices {
-			fmt.Fprintf(w, "\t\t\t\t\tVERTEX\n // %d\n", i)
+			fmt.Fprintf(w, "\t\t\t\t\tVERTEX // %d\n", i)
 			fmt.Fprintf(w, "\t\t\t\t\t\tXYZ %0.8e %0.8e %0.8e\n", vert.Position[0], vert.Position[1], vert.Position[2])
 			fmt.Fprintf(w, "\t\t\t\t\t\tUV %0.8e %0.8e\n", vert.Uv[0], vert.Uv[1])
 			fmt.Fprintf(w, "\t\t\t\t\t\tUV2 %0.8e %0.8e\n", vert.Uv2[0], vert.Uv2[1])
@@ -610,7 +610,7 @@ func (e *MdsDef) Write(token *AsciiWriteToken) error {
 
 			fmt.Fprintf(w, "\t\t\tNUMVERTICES %d\n", len(model.Vertices))
 			for i, vert := range model.Vertices {
-				fmt.Fprintf(w, "\t\t\t\t\tVERTEX\n // %d\n", i)
+				fmt.Fprintf(w, "\t\t\t\t\tVERTEX // %d\n", i)
 				fmt.Fprintf(w, "\t\t\t\t\t\tXYZ %0.8e %0.8e %0.8e\n", vert.Position[0], vert.Position[1], vert.Position[2])
 				fmt.Fprintf(w, "\t\t\t\t\t\tUV %0.8e %0.8e\n", vert.Uv[0], vert.Uv[1])
 				fmt.Fprintf(w, "\t\t\t\t\t\tUV2 %0.8e %0.8e\n", vert.Uv2[0], vert.Uv2[1])
@@ -1190,7 +1190,7 @@ func (e *TerDef) Write(token *AsciiWriteToken) error {
 		}
 		fmt.Fprintf(w, "\t\t\tNUMVERTICES %d\n", len(e.Vertices))
 		for i, vert := range e.Vertices {
-			fmt.Fprintf(w, "\t\t\t\t\tVERTEX\n // %d\n", i)
+			fmt.Fprintf(w, "\t\t\t\t\tVERTEX // %d\n", i)
 			fmt.Fprintf(w, "\t\t\t\t\t\tXYZ %0.8e %0.8e %0.8e\n", vert.Position[0], vert.Position[1], vert.Position[2])
 			fmt.Fprintf(w, "\t\t\t\t\t\tUV %0.8e %0.8e\n", vert.Uv[0], vert.Uv[1])
 			fmt.Fprintf(w, "\t\t\t\t\t\tUV2 %0.8e %0.8e\n", vert.Uv2[0], vert.Uv2[1])


### PR DESCRIPTION
All textures and raw data now resides in a subfolder of assets, this is to clean up root folder and make things more sane, especially later with things like animated textures in eqg's, .lit files (ray arrays of light data), having a folder that basically gets copied 1:1 to the final zip can be handy.