### PR TITLE
Bump go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,11 @@ jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.24.0'
+      - run: go version
       - run: go get ./...
       - run: go test -tags ci ./...
       - run: make sanitize

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,7 +7,11 @@ jobs:
   build_and_preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.24.0'
+      - run: go version
       - run: go get ./...
       - run: go test -tags ci ./...
       - run: make sanitize


### PR DESCRIPTION
CICD now forces 1.24, assuming this works