### PR TITLE
Add RenderMethod to BlitSpriteDef

### DIFF
--- a/raw/rawfrag/blit_sprite.go
+++ b/raw/rawfrag/blit_sprite.go
@@ -12,7 +12,7 @@ import (
 type WldFragBlitSprite struct {
 	nameRef       int32
 	BlitSpriteRef int32
-	Unknown       int32
+	Flags         uint32
 }
 
 func (e *WldFragBlitSprite) FragCode() int {
@@ -23,7 +23,7 @@ func (e *WldFragBlitSprite) Write(w io.Writer, isNewWorld bool) error {
 	enc := encdec.NewEncoder(w, binary.LittleEndian)
 	enc.Int32(e.nameRef)
 	enc.Int32(e.BlitSpriteRef)
-	enc.Int32(e.Unknown)
+	enc.Uint32(e.Flags)
 	err := enc.Error()
 	if err != nil {
 		return fmt.Errorf("write: %w", err)
@@ -35,7 +35,7 @@ func (e *WldFragBlitSprite) Read(r io.ReadSeeker, isNewWorld bool) error {
 	dec := encdec.NewDecoder(r, binary.LittleEndian)
 	e.nameRef = dec.Int32()
 	e.BlitSpriteRef = dec.Int32()
-	e.Unknown = dec.Int32()
+	e.Flags = dec.Uint32()
 	err := dec.Error()
 	if err != nil {
 		return fmt.Errorf("read: %w", err)

--- a/raw/rawfrag/blit_sprite_def.go
+++ b/raw/rawfrag/blit_sprite_def.go
@@ -13,7 +13,7 @@ type WldFragBlitSpriteDef struct {
 	nameRef           int32
 	Flags             uint32
 	SpriteInstanceRef uint32
-	Unknown           int32
+	RenderMethod      uint32
 }
 
 func (e *WldFragBlitSpriteDef) FragCode() int {
@@ -25,7 +25,7 @@ func (e *WldFragBlitSpriteDef) Write(w io.Writer, isNewWorld bool) error {
 	enc.Int32(e.nameRef)
 	enc.Uint32(e.Flags)
 	enc.Uint32(e.SpriteInstanceRef)
-	enc.Int32(e.Unknown)
+	enc.Uint32(e.RenderMethod)
 	err := enc.Error()
 	if err != nil {
 		return fmt.Errorf("write: %w", err)
@@ -39,7 +39,7 @@ func (e *WldFragBlitSpriteDef) Read(r io.ReadSeeker, isNewWorld bool) error {
 	e.nameRef = dec.Int32()
 	e.Flags = dec.Uint32()
 	e.SpriteInstanceRef = dec.Uint32()
-	e.Unknown = dec.Int32()
+	e.RenderMethod = dec.Uint32()
 
 	err := dec.Error()
 	if err != nil {

--- a/raw/rawfrag/track.go
+++ b/raw/rawfrag/track.go
@@ -8,7 +8,7 @@ import (
 	"github.com/xackery/encdec"
 )
 
-// WldFragTrack is a bone in a skeleton. It is Track in libeq, Mob Skeleton Piece Track Reference in openzone, TRACKINSTANCE in wld, TrackDefFragment in lantern
+// WldFragTrack is a bone in a skeleton. STrack in mq2nav, Track in libeq, Mob Skeleton Piece Track Reference in openzone, TRACKINSTANCE in wld, TrackDefFragment in lantern
 type WldFragTrack struct {
 	nameRef  int32
 	TrackRef int32

--- a/wce/wce_wld.go
+++ b/wce/wce_wld.go
@@ -2129,12 +2129,12 @@ func (e *MaterialDef) variationParseFromRaw(wce *Wce, frag *rawfrag.WldFragMater
 
 // BlitSpriteDef is a declaration of BLITSPRITEDEF
 type BlitSpriteDef struct {
-	folders     []string // when writing, this is the folder the file is in
-	fragID      int16
-	Tag         string
-	SpriteTag   string
-	Unknown     int32
-	Transparent int16
+	folders      []string // when writing, this is the folder the file is in
+	fragID       int16
+	Tag          string
+	SpriteTag    string
+	RenderMethod string
+	Transparent  int16
 }
 
 func (e *BlitSpriteDef) Definition() string {
@@ -2165,7 +2165,7 @@ func (e *BlitSpriteDef) Write(token *AsciiWriteToken) error {
 
 		fmt.Fprintf(w, "%s \"%s\"\n", e.Definition(), e.Tag)
 		fmt.Fprintf(w, "\tSPRITE \"%s\"\n", e.SpriteTag)
-		fmt.Fprintf(w, "\tUNKNOWN %d\n", e.Unknown)
+		fmt.Fprintf(w, "\tRENDERMETHOD \"%s\"\n", e.RenderMethod)
 		fmt.Fprintf(w, "\tTRANSPARENT %d\n", e.Transparent)
 		fmt.Fprintf(w, "\n")
 	}
@@ -2182,15 +2182,12 @@ func (e *BlitSpriteDef) Read(token *AsciiReadToken) error {
 	}
 	e.SpriteTag = records[1]
 
-	records, err = token.ReadProperty("UNKNOWN", 1)
+	records, err = token.ReadProperty("RENDERMETHOD", 1)
 	if err != nil {
-		return fmt.Errorf("UNKNOWN: %w", err)
+		return fmt.Errorf("RENDERMETHOD: %w", err)
 	}
 
-	err = parse(&e.Unknown, records[1])
-	if err != nil {
-		return fmt.Errorf("unknown: %w", err)
-	}
+	e.RenderMethod = records[1]
 
 	records, err = token.ReadProperty("TRANSPARENT", 1)
 	if err != nil {
@@ -2234,7 +2231,7 @@ func (e *BlitSpriteDef) ToRaw(wce *Wce, rawWld *raw.Wld) (int16, error) {
 	spriteRef := int16(len(rawWld.Fragments))
 
 	wfBlitSpriteDef := &rawfrag.WldFragBlitSpriteDef{
-		Unknown:           e.Unknown,
+		RenderMethod:      helper.RenderMethodInt(e.RenderMethod),
 		SpriteInstanceRef: uint32(spriteRef),
 	}
 
@@ -2278,7 +2275,7 @@ func (e *BlitSpriteDef) FromRaw(wce *Wce, rawWld *raw.Wld, frag *rawfrag.WldFrag
 		e.SpriteTag = rawWld.Name(spriteDef.NameRef())
 	}
 
-	e.Unknown = frag.Unknown
+	e.RenderMethod = helper.RenderMethodStr(frag.RenderMethod)
 	e.Transparent = int16(frag.Flags & 0x100)
 	return nil
 }


### PR DESCRIPTION
This should not have any real consequences, but let me know if you see a blit with a render method unknown.. This is based on brainiac's latest work.