### PR TITLE
Fix DRA to write to .quail, animations subfolder support

### DIFF
--- a/helper/ani.go
+++ b/helper/ani.go
@@ -79,6 +79,7 @@ func TrackAnimationParse(isChr bool, tag string) (animationTag string, modelTag 
 
 		patterns := []string{
 			`^[C,D,L,O,P,S,T](0[1-9]|[1-9][0-9])([A-Z]){3}_TRACK$`,
+			`^([C,D,L,O,P,S,T](0[1-9]|[1-9][0-9])){2}[A-Z]{3}_TRACK$`,
 			`^([C,D,L,O,P,S,T](0[1-9]|[1-9][0-9])){2}_[A-Z]{3}_TRACK$`,
 			`^[C,D,L,O,P,S,T](0[1-9]|[1-9][0-9])[A-Z]{3}[C,D,L,O,P,S,T](0[1-9]|[1-9][0-9])[A-Z]{3}_TRACK`,
 			`^[C,D,L,O,P,S,T](0[1-9]|[1-9][0-9])[A-Z]{3}[C,D,L,O,P,S,T](0[1-9]|[1-9][0-9])_[A-Z]{3}_TRACK$`,
@@ -94,12 +95,14 @@ func TrackAnimationParse(isChr bool, tag string) (animationTag string, modelTag 
 				case 0: // Pattern 1
 					return handleNewAniModelCode(tag[:3], tag[3:6])
 				case 1: // Pattern 2
+					return handleNewAniModelCode(tag[:3], tag[6:9])
+				case 2: // Pattern 3
 					return handleNewAniModelCode(tag[:3], tag[7:10])
-				case 2, 3: // Pattern 3 and 4
+				case 3, 4: // Pattern 4 and 5
 					return handleNewAniModelCode(tag[:3], tag[3:6])
-				case 4: // Pattern 5
-					return handleNewAniModelCode(tag[:4], tag[4:7])
 				case 5: // Pattern 6
+					return handleNewAniModelCode(tag[:4], tag[4:7])
+				case 6: // Pattern 7
 					return handleNewAniModelCode(tag[:4], tag[8:11])
 				}
 			}

--- a/quail/dir_read.go
+++ b/quail/dir_read.go
@@ -55,7 +55,7 @@ func (q *Quail) DirRead(path string) error {
 	}
 
 	dirs, err := os.ReadDir(path + "/assets")
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	for _, dir := range dirs {

--- a/wce/ascii_writer.go
+++ b/wce/ascii_writer.go
@@ -61,9 +61,14 @@ func (a *AsciiWriteToken) SetWriter(tag string) error {
 	w, ok := a.writers[tag]
 	if !ok {
 		rootFolder := tag
+
 		if strings.Contains(rootFolder, "/") {
-			rootFolder = strings.Split(rootFolder, "/")[0]
-			tag = strings.Split(tag, "/")[1]
+			chunks := strings.Split(rootFolder, "/")
+			rootFolder = chunks[0]
+			for i := 1; i < len(chunks)-1; i++ {
+				rootFolder += "/" + chunks[i]
+			}
+			tag = chunks[len(chunks)-1]
 			isSubfolder = true
 		}
 

--- a/wce/def/materialdefinition.yaml
+++ b/wce/def/materialdefinition.yaml
@@ -55,6 +55,12 @@ properties:
       - name: "tag"
         note: "Simple sprite instance tag"
         format: "%s"
+  - name: "SIMPLESPRITETAGINDEX"
+    note: ""
+    args:
+      - name: ""
+        note: ""
+        format: "%d"
   - name: "HEXFIFTYFLAG"
     note: "Hex fifty flag"
     args:

--- a/wce/wce_ascii.go
+++ b/wce/wce_ascii.go
@@ -312,6 +312,7 @@ func (wce *Wce) writeAsciiData(path string) error {
 	sort.Strings(sortedFolders)
 
 	writtenSubfolders := make(map[string]bool)
+	writtenRoots := make(map[string]bool)
 	for _, folder := range sortedFolders {
 		folderInfo, ok := folders[folder]
 		if !ok {
@@ -344,11 +345,18 @@ func (wce *Wce) writeAsciiData(path string) error {
 			}
 
 			writtenSubfolders[parentFolder] = true
+			if !writtenRoots[parentFolder] {
+				rootW.WriteString(fmt.Sprintf("INCLUDE \"%s/_ROOT.WCE\"\n", strings.ToUpper(parentFolder)))
+				writtenRoots[parentFolder] = true
+			}
 
 			continue
 		}
 
-		rootW.WriteString(fmt.Sprintf("INCLUDE \"%s/_ROOT.WCE\"\n", strings.ToUpper(folder)))
+		if !writtenRoots[folder] {
+			rootW.WriteString(fmt.Sprintf("INCLUDE \"%s/_ROOT.WCE\"\n", strings.ToUpper(folder)))
+			writtenRoots[folder] = true
+		}
 		if folderInfo.hasBase {
 			includes[folder] += fmt.Sprintf("INCLUDE \"%s.WCE\"\n", strings.ToUpper(folder))
 		}

--- a/wce/wce_ascii.go
+++ b/wce/wce_ascii.go
@@ -319,10 +319,20 @@ func (wce *Wce) writeAsciiData(path string) error {
 		}
 
 		if strings.Contains(folder, "/") {
-			rootFolder := strings.Split(folder, "/")[0]
-			tag := strings.Split(folder, "/")[1]
-			if _, ok := writtenSubfolders[rootFolder]; !ok {
-				rootW.WriteString(fmt.Sprintf("INCLUDE \"%s/_ROOT.WCE\"\n", strings.ToUpper(rootFolder)))
+			chunks := strings.Split(folder, "/")
+			rootFolder := chunks[0]
+			parentFolder := chunks[0]
+			parentSubfolder := ""
+			for i := 1; i < len(chunks)-1; i++ {
+				rootFolder += "/" + chunks[i]
+				parentSubfolder += "/" + chunks[i]
+			}
+			parentSubfolder = strings.TrimLeft(parentSubfolder, "/")
+
+			tag := chunks[len(chunks)-1]
+			ok := writtenSubfolders[parentFolder]
+			if !ok {
+				includes[parentFolder] += fmt.Sprintf("INCLUDE \"%s/_ROOT.WCE\"\n", strings.ToUpper(parentSubfolder))
 			}
 
 			if folderInfo.hasBase {
@@ -333,7 +343,7 @@ func (wce *Wce) writeAsciiData(path string) error {
 				includes[rootFolder] += fmt.Sprintf("INCLUDE \"%s_ANI.WCE\"\n", strings.ToUpper(tag))
 			}
 
-			writtenSubfolders[rootFolder] = true
+			writtenSubfolders[parentFolder] = true
 
 			continue
 		}

--- a/wce/wce_wld.go
+++ b/wce/wce_wld.go
@@ -4593,7 +4593,7 @@ func (e *TrackInstance) Write(token *AsciiWriteToken) error {
 	for _, folder := range e.folders {
 		var filename string
 		if e.animation != "" {
-			filename = fmt.Sprintf("%s/%s_%s", folder, strings.ToLower(e.animation), strings.ToLower(folder))
+			filename = fmt.Sprintf("%s/animations/%s_%s", folder, strings.ToLower(e.animation), strings.ToLower(folder))
 		} else {
 			filename = folder
 		}
@@ -4805,7 +4805,7 @@ func (e *TrackDef) Write(token *AsciiWriteToken) error {
 	for _, folder := range e.folders {
 		var filename string
 		if e.animation != "" {
-			filename = fmt.Sprintf("%s/%s_%s", folder, strings.ToLower(e.animation), strings.ToLower(folder))
+			filename = fmt.Sprintf("%s/animations/%s_%s", folder, strings.ToLower(e.animation), strings.ToLower(folder))
 		} else {
 			filename = folder
 		}

--- a/wce/wce_wld.go
+++ b/wce/wce_wld.go
@@ -4806,7 +4806,7 @@ func (e *TrackDef) Write(token *AsciiWriteToken) error {
 
 		fmt.Fprintf(w, "%s \"%s\"\n", e.Definition(), e.Tag)
 		fmt.Fprintf(w, "\tTAGINDEX %d\n", e.TagIndex)
-		fmt.Fprintf(w, "\tNUMFRAMES %d //Format: FRAME [scale x-loc y-loc z-loc w-rot x-rot y-rot z-rot]\n", len(e.Frames))
+		fmt.Fprintf(w, "\tNUMFRAMES %d // Format: FRAME [scale x-loc y-loc z-loc w-rot x-rot y-rot z-rot]\n", len(e.Frames))
 		for _, frame := range e.Frames {
 			fmt.Fprintf(w, "\t\tFRAME %d %d %d %d ", frame.XYZScale, frame.XYZ[0], frame.XYZ[1], frame.XYZ[2])
 			fmt.Fprintf(w, "%d %d %d %d\n", frame.RotScale, frame.Rotation[0], frame.Rotation[1], frame.Rotation[2])

--- a/wce/wce_wld.go
+++ b/wce/wce_wld.go
@@ -1802,20 +1802,21 @@ func (e *MaterialPalette) FromRaw(wce *Wce, rawWld *raw.Wld, frag *rawfrag.WldFr
 
 // MaterialDef is an entry MATERIALDEFINITION
 type MaterialDef struct {
-	folders            []string // when writing, this is the folder the file is in
-	fragID             int16
-	Tag                string
-	TagIndex           int
-	Variation          int
-	SpriteHexFiftyFlag int
-	RenderMethod       string
-	RGBPen             [4]uint8
-	Brightness         float32
-	ScaledAmbient      float32
-	SimpleSpriteTag    string
-	Pair1              NullUint32
-	Pair2              NullFloat32
-	DoubleSided        int
+	folders              []string // when writing, this is the folder the file is in
+	fragID               int16
+	Tag                  string
+	TagIndex             int
+	Variation            int
+	SpriteHexFiftyFlag   int
+	RenderMethod         string
+	RGBPen               [4]uint8
+	Brightness           float32
+	ScaledAmbient        float32
+	SimpleSpriteTag      string
+	SimpleSpriteTagIndex int
+	Pair1                NullUint32
+	Pair2                NullFloat32
+	DoubleSided          int
 }
 
 func (e *MaterialDef) Definition() string {
@@ -1836,7 +1837,7 @@ func (e *MaterialDef) Write(token *AsciiWriteToken) error {
 
 		if e.SimpleSpriteTag != "" {
 
-			simpleSprite := token.wce.ByTagWithIndex(e.SimpleSpriteTag, e.TagIndex)
+			simpleSprite := token.wce.ByTagWithIndex(e.SimpleSpriteTag, e.SimpleSpriteTagIndex)
 			if simpleSprite == nil {
 				return fmt.Errorf("simple sprite %s not found", e.SimpleSpriteTag)
 			}
@@ -1855,6 +1856,7 @@ func (e *MaterialDef) Write(token *AsciiWriteToken) error {
 		fmt.Fprintf(w, "\tSCALEDAMBIENT %0.8e\n", e.ScaledAmbient)
 		fmt.Fprintf(w, "\tSIMPLESPRITEINST\n")
 		fmt.Fprintf(w, "\t\tTAG \"%s\"\n", e.SimpleSpriteTag)
+		fmt.Fprintf(w, "\t\tSIMPLESPRITETAGINDEX %d\n", e.SimpleSpriteTagIndex)
 		fmt.Fprintf(w, "\t\tHEXFIFTYFLAG %d\n", e.SpriteHexFiftyFlag)
 		fmt.Fprintf(w, "\tPAIRS? %s %s\n", wcVal(e.Pair1), wcVal(e.Pair2))
 		fmt.Fprintf(w, "\tDOUBLESIDED %d\n", e.DoubleSided)
@@ -1930,6 +1932,15 @@ func (e *MaterialDef) Read(token *AsciiReadToken) error {
 	}
 	e.SimpleSpriteTag = records[1]
 
+	records, err = token.ReadProperty("SIMPLESPRITETAGINDEX", 1)
+	if err != nil {
+		return err
+	}
+	err = parse(&e.SimpleSpriteTagIndex, records[1])
+	if err != nil {
+		return fmt.Errorf("simple sprite tag index: %w", err)
+	}
+
 	records, err = token.ReadProperty("HEXFIFTYFLAG", 1)
 	if err != nil {
 		return err
@@ -1993,7 +2004,7 @@ func (e *MaterialDef) ToRaw(wce *Wce, rawWld *raw.Wld) (int16, error) {
 	}
 
 	if e.SimpleSpriteTag != "" {
-		spriteDef := wce.ByTag(e.SimpleSpriteTag)
+		spriteDef := wce.ByTagWithIndex(e.SimpleSpriteTag, e.SimpleSpriteTagIndex)
 		if spriteDef == nil {
 			return -1, fmt.Errorf("simple sprite %s not found", e.SimpleSpriteTag)
 		}
@@ -2051,6 +2062,7 @@ func (e *MaterialDef) FromRaw(wce *Wce, rawWld *raw.Wld, frag *rawfrag.WldFragMa
 		}
 
 		e.SimpleSpriteTag = rawWld.Name(spriteDef.NameRef())
+		e.SimpleSpriteTagIndex = wce.tagIndexes[rawWld.Name(spriteDef.NameRef())]
 	}
 	e.Tag = rawWld.Name(frag.NameRef())
 	e.TagIndex = wce.NextTagIndex(e.Tag)

--- a/wce/wce_wld.go
+++ b/wce/wce_wld.go
@@ -4591,7 +4591,15 @@ func (e *TrackInstance) Definition() string {
 
 func (e *TrackInstance) Write(token *AsciiWriteToken) error {
 	for _, folder := range e.folders {
-		err := token.SetWriter(folder)
+		var filename string
+		if e.animation != "" {
+			filename = fmt.Sprintf("%s/%s_%s", folder, strings.ToLower(e.animation), strings.ToLower(folder))
+		} else {
+			filename = folder
+		}
+
+		// Set the writer for the determined filename
+		err := token.SetWriter(filename)
 		if err != nil {
 			return err
 		}
@@ -4795,7 +4803,15 @@ func (e *TrackDef) Definition() string {
 
 func (e *TrackDef) Write(token *AsciiWriteToken) error {
 	for _, folder := range e.folders {
-		err := token.SetWriter(folder)
+		var filename string
+		if e.animation != "" {
+			filename = fmt.Sprintf("%s/%s_%s", folder, strings.ToLower(e.animation), strings.ToLower(folder))
+		} else {
+			filename = folder
+		}
+
+		// Set the writer for the determined filename
+		err := token.SetWriter(filename)
 		if err != nil {
 			return err
 		}

--- a/wce/wld_test/single_test.go
+++ b/wce/wld_test/single_test.go
@@ -8,7 +8,7 @@ import (
 
 var tests = []testEntry{
 	//{baseName: "gequip"}, // soul binder uses  IT124, IT124_MP uses 114CRYSBLAK_MDF, probably a rendermethod on that. Will have to wait, I'm working on improvements for quail to work with gequip, but should be doable
-	{baseName: "twilight"},
+	//{baseName: "twilight"},
 	//{baseName: "global_chr"},
 	//{baseName: "globalelf_chr"},
 	//{baseName: "emeraldjungle"},
@@ -83,9 +83,10 @@ var tests = []testEntry{
 	//{baseName: "qeynos", wldName: "lights.wld"},
 	//{baseName: "globalogm_chr"},
 
-	{baseName: "acrylia_obj"}, //acrylia_obj failed to write acrylia_obj: hierarchicalsprite ACTORCH301_HS_DEF: collision volume not found: I_L301_SPB
+	//{baseName: "acrylia_obj"}, //acrylia_obj failed to write acrylia_obj: hierarchicalsprite ACTORCH301_HS_DEF: collision volume not found: I_L301_SPB
 	// {baseName: "ael_chr"}, //failed to write ael_chr: actordef AEL_ACTORDEF: sprite AEL_HS_DEF to raw: collision volume not found: I_AELCLOUD01_SPB
 	//{baseName: "gequip.takp", wldName: "gequip.wld"},
+	{baseName: "dra_chr"}, // fails at DRAHE0212_MDF. There are 2 materials with same name but different simplesprites.
 
 }
 


### PR DESCRIPTION
Some materialdefs have the same name but different simplespritedefs. Some simplespritedefs have the same name but different BMinfo. Needs to be indexed properly. 