### PR TITLE
No wld fix

### DIFF
--- a/quail/dir_read.go
+++ b/quail/dir_read.go
@@ -22,7 +22,23 @@ func (q *Quail) DirRead(path string) error {
 
 	fi, err = os.Stat(path + "/_root.wce")
 	if err != nil {
-		return err
+		// there's a fallback case where only assets are being packed
+		dirs, err := os.ReadDir(path + "/assets")
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		for _, dir := range dirs {
+			if dir.IsDir() {
+				continue
+			}
+			textureData, err := os.ReadFile(path + "/assets/" + dir.Name())
+			if err != nil {
+				return err
+			}
+			q.assetAdd(dir.Name(), textureData)
+		}
+		return nil
+
 	}
 	if fi.IsDir() {
 		return fmt.Errorf("path %s is a directory, but should be a file", path+"/_root.wce")

--- a/quail/pfs_read.go
+++ b/quail/pfs_read.go
@@ -54,6 +54,11 @@ func (q *Quail) PfsRead(path string) error {
 		}
 	}
 
+	if q.Wld == nil {
+		// edge cases like grass.s3d has no wld data
+		return nil
+	}
+
 	summary := ""
 	if len(q.Wld.TerDefs) > 0 {
 		summary = fmt.Sprintf("%s%d terrain, ", summary, len(q.Wld.TerDefs))


### PR DESCRIPTION
This is a case in like, grass.s3d, where no .wld file is found, this basically falls back to just copying assets over and letting you restore it.